### PR TITLE
Create a workaround to MacGyver show in DVC tests. 

### DIFF
--- a/helper/cbs.py
+++ b/helper/cbs.py
@@ -228,15 +228,15 @@ class CommonHelper(TestlioAutomationTest):
         self.open_drawer()
         self._go_to('Movies')
 
-    def goto_show(self, show_name, select_second_show):
+    def goto_show(self, show_name, select_second_show=False):
         self.select_search_icon()
         self.wait_for_show_page_to_load()
 
         self.send_keys_on_search_field(show_name)
-        if not select_second_show:
-            self.click_first_search_result()
-        else:
+        if select_second_show:
             self.click_second_search_result()
+        else:
+            self.click_first_search_result()
         sleep(10)
 
     def goto_show_with_extended_search(self, show_name):

--- a/helper/cbs.py
+++ b/helper/cbs.py
@@ -228,12 +228,15 @@ class CommonHelper(TestlioAutomationTest):
         self.open_drawer()
         self._go_to('Movies')
 
-    def goto_show(self, show_name):
+    def goto_show(self, show_name, select_second_show):
         self.select_search_icon()
         self.wait_for_show_page_to_load()
 
         self.send_keys_on_search_field(show_name)
-        self.click_first_search_result()
+        if not select_second_show:
+            self.click_first_search_result()
+        else:
+            self.click_second_search_result()
         sleep(10)
 
     def goto_show_with_extended_search(self, show_name):
@@ -1829,7 +1832,11 @@ class CommonHelper(TestlioAutomationTest):
 
     def click_first_search_result(self):
         # this is how we did it in 2.9
-        self.tap(.25, .25, 'first search result')
+        self.tap(.25, .25, 'first search result')    
+
+    def click_second_search_result(self):
+        # this is how we did it in 2.9
+        self.tap(.55, .25, 'second search result')
 
     def collect_details_from_show_info_page(self):
         show_dict_found = {}


### PR DESCRIPTION
-Adds new method 'click_second_search_result(self)' that will select the second search result using similar methodology to 'click_first_search_result(self)'. Tested working on Android phone and Android tablet.
-Adds a new parameter to 'goto_show(self, show_name)' called 'select_second_show' - a boolean value defaulting to False that when set to true will call the newly added method 'click_second_search_result(self)' and if not will call  'click_first_search_result(self)'.

Fulfills Asana ticket: https://app.asana.com/0/507001656060819/528013241328148